### PR TITLE
Add example scripts to run on the Wilson Cluster

### DIFF
--- a/galaxy_merge_edits/wilson_cluster/galaxy_train_exe.sh
+++ b/galaxy_merge_edits/wilson_cluster/galaxy_train_exe.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "started "`date`" "`date +%s`""
+
+BASEPATH="/home/${USER}/DeepMergeDomainAdaptation/galaxy_merge_edits"
+
+cp ${BASEPATH}/*.py ./
+
+EXE="galaxy_train.py"
+
+ARGS="--gpu_id 0"   # think we shouldn't pass this...
+ARGS+=" --net ResNet18"
+ARGS+=" --dset galaxy"
+ARGS+=" --dset_path  /data/perdue/dmda/small/"
+ARGS+=" --pristine_xfile Pristine_small.npy"
+ARGS+=" --pristine_yfile Pristine_small_labels.npy"
+ARGS+=" --noisy_xfile Noisy_small.npy"
+ARGS+=" --noisy_yfile Noisy_small_labels.npy"
+ARGS+=" --test_interval 500"
+ARGS+=" --snapshot_interval 10000"
+ARGS+=" --ly_type cosine"
+ARGS+=" --loss_type mmd"
+ARGS+=" --fisher_loss_type tr"
+ARGS+=" --output_dir log_output"
+ARGS+=" --em_loss_coef 0.1"
+ARGS+=" --inter_loss_coef 1."
+ARGS+=" --intra_loss_coef 1."
+ARGS+=" --trade_off 1."
+ARGS+=" --optim_choice 'SGD'"
+
+
+SNGLRTY="/data/perdue/singularity/gnperdue-singularity_imgs-master-py3_dmda.simg"
+
+cat << EOF
+singularity exec --nv $SNGLRTY python3 $EXE $ARGS
+EOF
+singularity exec --nv $SNGLRTY python3 $EXE $ARGS

--- a/galaxy_merge_edits/wilson_cluster/sbatch_submit_galaxy_train_exe.sh
+++ b/galaxy_merge_edits/wilson_cluster/sbatch_submit_galaxy_train_exe.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SCRIPTKEY=`date +%s`
+mkdir job${SCRIPTKEY}
+
+NGPU=1
+NODES=gpu2
+NODES=gpu3
+NODES=gpu4
+
+EXE="galaxy_train_exe.sh"
+GROUP="accelai"
+
+cat << EOF
+sbatch --gres=gpu:${NGPU} --nodelist=${NODES} -A $GROUP -p gpu $EXE
+EOF
+
+# do the thing, etc.
+cp ${EXE} job${SCRIPTKEY}
+pushd job${SCRIPTKEY}
+sbatch --gres=gpu:${NGPU} --nodelist=${NODES} -A $GROUP -p gpu $EXE
+popd


### PR DESCRIPTION
I have not made them "nice" in the sense that there are still some user-specific values hard-coded in the paths. But that would be pretty easy to fix (could copy the script or tweak the existing one). If we had a central data area on Wilson, we could read from there and write logs based on `$USER` paths, etc.